### PR TITLE
Fix: Typo in "bin" object within package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     },
     "bin": {
         "objj": "./bin/objj",
-        "objc": "./bin/objc"
+        "objjc": "./bin/objjc"
     }
 }


### PR DESCRIPTION
This typo prevents NPM to install this package.