### PR TITLE
Resolve relative symlinks in objj infile path.

### DIFF
--- a/footer.js
+++ b/footer.js
@@ -156,7 +156,11 @@ exports.run = function(args, someCompilerOptions)
 
         // resolve and read all links
         while ((NODEFILE.existsSync(mainFilePath) && NODEFILE.lstatSync(mainFilePath).isSymbolicLink())) {
-            mainFilePath = PATH.resolve(NODEFILE.readlinkSync(mainFilePath))
+            var linkPath = NODEFILE.readlinkSync(mainFilePath);
+            if (!PATH.isAbsolute(linkPath)) {
+               mainFilePath = PATH.join(PATH.dirname(mainFilePath), linkPath);
+            }
+            mainFilePath = PATH.resolve(mainFilePath);
         }
 
         options.acornOptions = acornOptions;


### PR DESCRIPTION
This resolves a situation where the infile is a relative symlink.

For example, I installed cappuccino globally with a prefix (with
`npm install -g @objj/cappuccino --prefix=$HOME/cappnpm/inst`). All
binaries then ended up in `$HOME/cappnpm/inst/bin` with each binary
pointing to their respective actual file somewhere deep inside
`$HOME/cappnpm/inst/lib`. These symlinks where relative however, e.g.,

  $HOME/cappnpm/inst/bin/jake

  linked to

  ../lib/node_modules/@objj/cappuccino/dist/cappuccino/bin/jake

When handing objj one of these paths, the symlink would be resolved
relative the current working directory, not relative the dir of the
link itself.